### PR TITLE
Fix "mcux_lpuart_irq_tx_complete" returns wrong relult

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -132,16 +132,17 @@ static int mcux_lpuart_irq_tx_complete(struct device *dev)
 	const struct mcux_lpuart_config *config = dev->config->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 
-	return (flags & kLPUART_TxDataRegEmptyFlag) != 0U;
+	return (flags & kLPUART_TransmissionCompleteFlag) != 0U;
 }
 
 static int mcux_lpuart_irq_tx_ready(struct device *dev)
 {
 	const struct mcux_lpuart_config *config = dev->config->config_info;
 	u32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
+	u32_t flags = LPUART_GetStatusFlags(config->base);
 
 	return (LPUART_GetEnabledInterrupts(config->base) & mask)
-		&& mcux_lpuart_irq_tx_complete(dev);
+		&& (flags & kLPUART_TxDataRegEmptyFlag);
 }
 
 static void mcux_lpuart_irq_rx_enable(struct device *dev)


### PR DESCRIPTION
1. Use `kLPUART_TransmissionCompleteFlag` instead of `kLPUART_TxDataRegEmptyFlag` to check if the tx transmition is finished.
2. This change would be pull in zephyr master soon. See [here](https://github.com/zephyrproject-rtos/zephyr/pull/26069)

Signed-off-by: Andy Liu <andy@madmachine.io>