### PR TITLE
fix fatfs name len

### DIFF
--- a/include/fs/fs_interface.h
+++ b/include/fs/fs_interface.h
@@ -11,10 +11,14 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_FILE_SYSTEM_LITTLEFS)  || defined(CONFIG_FS_FATFS_LFN)
+#if defined(CONFIG_FILE_SYSTEM_LITTLEFS)
 #define MAX_FILE_NAME 256
 #else /* FAT_FS */
+#if defined(CONFIG_FS_FATFS_LFN)
+#define MAX_FILE_NAME CONFIG_FS_FATFS_MAX_LFN
+#else
 #define MAX_FILE_NAME 12 /* Uses 8.3 SFN */
+#endif
 #endif
 
 struct fs_mount_t;


### PR DESCRIPTION
For fatfs name modify MAX_FILE_NAME to CONFIG_FS_FATFS_MAX_LFN

Signed-off-by: Frank Li <lgl88911@163.com>