### PR TITLE
Add device support for feather

### DIFF
--- a/boards/arm/mm_feather/mm_feather.dts
+++ b/boards/arm/mm_feather/mm_feather.dts
@@ -72,7 +72,17 @@
 	current-speed = <115200>;
 };
 
+&lpuart3 {
+	status = "okay";
+	current-speed = <115200>;
+};
+
 &lpuart4 {
+	status = "okay";
+	current-speed = <115200>;
+};
+
+&lpuart8 {
 	status = "okay";
 	current-speed = <115200>;
 };
@@ -97,6 +107,10 @@
 	pcs-sck-delay = <2>;
 	sck-pcs-delay = <2>;
 	transfer-delay = <2>;
+};
+
+&flexpwm1_pwm3 {
+	status = "okay";
 };
 
 &flexpwm2_pwm0 {

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -617,7 +617,7 @@ enum usdhc_capability_flag {
 		USDHC_HOST_CTRL_CAP_VS30_MASK,
 	/*!< Support voltage 3.0V */
 	USDHC_SUPPORT_V180_FLAG =
-#if defined(CONFIG_BOARD_MM_SWIFTIO)
+#if defined(CONFIG_BOARD_MM_SWIFTIO) || defined(CONFIG_BOARD_MM_FEATHER)
 		SDMMCHOST_NOT_SUPPORT,
 	/*!< No Support voltage 1.8V */
 #else


### PR DESCRIPTION
1. add uart/pwm device node
2. add usdhc 3.3V support for feather

Signed-off-by: Frank Li <lgl88911@163.com>