### PR TITLE
Fix usdhc.disk_usdhc_access_write busy fail

### DIFF
--- a/drivers/disk/usdhc.c
+++ b/drivers/disk/usdhc.c
@@ -912,8 +912,8 @@ static int usdhc_data_xfer_cfg(struct usdhc_priv *priv,
 		}
 
 		/* check data inhibit flag */
-		if (base->PRES_STATE & USDHC_DATA_INHIBIT_FLAG)
-			return -EBUSY;
+		while (base->PRES_STATE & USDHC_DATA_INHIBIT_FLAG);
+			/* return -EBUSY; */
 		/* check transfer block count */
 		if ((data->block_count > USDHC_MAX_BLOCK_COUNT) ||
 			(!data->tx_data && !data->rx_data))


### PR DESCRIPTION
For unknown reasons, calling disk_usdhc_access_write continuously
will check that the CDIHB field of the register PRES_STATE is 1
after the previous transfer is completed and before the next transfer.

This phenomenon is more likely to occur. May be a SOC issue, and more
experiments are needed to confirm.

This is a temporary solution, wait for CDIHB to become 0 before
transmitting data.

Signed-off-by: Frank Li <lgl88911@163.com>