### PR TITLE
Modify Kconfig to remove header

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -591,11 +591,11 @@ config CODE_ITCM
 
 config CODE_FLEXSPI
 	bool "Link code into external FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_FLEXSPI2
 	bool "Link code into internal FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_SRAM0
 	bool "Link code into RAM_L memory (RAM_L)"


### PR DESCRIPTION
When bootloader isn't mucboot, There is also a need to delete the boot
header.