### PR TITLE
Sync flash driver priority settings from main

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -58,6 +58,14 @@ config FLASH_PAGE_LAYOUT
 	help
 	  Enables API for retrieving the layout of flash memory pages.
 
+config FLASH_INIT_PRIORITY
+	int "Flash init priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  Flash driver device initialization priority. This initialization
+	  priority is used unless the driver implementation has its own
+	  initialization priority
+
 source "drivers/flash/Kconfig.b91"
 
 source "drivers/flash/Kconfig.at45"

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -497,6 +497,7 @@ static int flash_flexspi_nor_init(const struct device *dev)
 	uint8_t vendor_id;
 
 	data->controller = device_get_binding(config->controller_label);
+
 	if (data->controller == NULL) {
 		LOG_ERR("Could not find controller");
 		return -EINVAL;
@@ -600,7 +601,7 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 			      &flash_flexspi_nor_data_##n,		\
 			      &flash_flexspi_nor_config_##n,		\
 			      POST_KERNEL,				\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_FLASH_INIT_PRIORITY,		\
 			      &flash_flexspi_nor_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FLASH_FLEXSPI_NOR)


### PR DESCRIPTION
Synchronize flash driver priority settings from main to get confirmed
initialization sequence.

Signed-off-by: Frank Li <lgl88911@163.com>